### PR TITLE
Fix stack overflow error in `deduplicatePipeline`

### DIFF
--- a/lib/operators.ts
+++ b/lib/operators.ts
@@ -33,6 +33,10 @@ export function buildPipeline(
   );
 }
 
+function deduplicatePipeline(steps: StepLikeOpts[]) {
+  return aggregator([], steps);
+}
+
 function stepHasMatchingKey(key?: string) {
   return function (step: StepLikeOpts) {
     return ("key" in step) && step.key === key;
@@ -63,10 +67,6 @@ function aggregator(
   }
 
   return aggregator(nextAgg, tail);
-}
-
-function deduplicatePipeline(steps: StepLikeOpts[]) {
-    return aggregator([], steps);
 }
 
 export function inlineScript(

--- a/lib/operators.ts
+++ b/lib/operators.ts
@@ -59,11 +59,11 @@ function deduplicatePipeline(steps: StepLikeOpts[]) {
       ...(isNewStep ? [head] : []),
     ];
 
-    if (tail.length > 0) {
-      return aggregator(nextAgg, tail);
-    } else {
+    if (tail.length === 0) {
       return nextAgg;
     }
+
+    return aggregator(nextAgg, tail);
   }
 
   return aggregator([], steps);


### PR DESCRIPTION
The `deduplicatePipeline` function has the ability to introduce stack overflow errors as seen here:
https://buildkite.com/ailohq/consumer-mobile-app/builds/47#fa4d5891-0411-4494-9705-fd9ef06f71c9

Deno doesn't support tail recursion optimisation so if our stack grows too large we get the above error.

The implementation of this function doesn't seem to rely heavily on recursion and I believe can be simplified to a `reduce` call instead.