### PR TITLE
use sh as default shell

### DIFF
--- a/lib/operators.ts
+++ b/lib/operators.ts
@@ -60,7 +60,7 @@ function deduplicatePipeline(steps: StepLikeOpts[]) {
 
 export function inlineScript(
   docs: string | string[],
-  { delimiter = "EOF", stripMargin = true, shell = "bash -e" } = {},
+  { delimiter = "EOF", stripMargin = true, shell = "sh -e" } = {},
 ): string[] {
   const lineStartsWithWhitespace = /^(\s*).*$/;
   if (typeof docs === "string") {
@@ -102,7 +102,7 @@ export function inlineScript(
     .join("\n");
 
   return [
-    "bash",
+    "sh",
     "-ec",
     shell + " <<'EOF'\n" + script + "EOF",
   ];

--- a/lib/operators.ts
+++ b/lib/operators.ts
@@ -60,7 +60,7 @@ function deduplicatePipeline(steps: StepLikeOpts[]) {
 
 export function inlineScript(
   docs: string | string[],
-  { delimiter = "EOF", stripMargin = true, shell = "sh -e" } = {},
+  { delimiter = "EOF", stripMargin = true, shell = "bash -e" } = {},
 ): string[] {
   const lineStartsWithWhitespace = /^(\s*).*$/;
   if (typeof docs === "string") {


### PR DESCRIPTION
node-alpine does not support `bash` shell.
I wonder if we should stick to `sh` as the default unless someone needs the extra power of `bash` explicitly for better compatibility.